### PR TITLE
remove signup temporarily, it involves page templates the project does not have

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -140,8 +140,6 @@ export default apostrophe({
     */
     ...getTranslationAndSeoModules(),
 
-    '@apostrophecms-pro/signup': {},
-
     '@apostrophecms-pro/document-versions': {},
     '@apostrophecms-pro/doc-template-library': {},
     '@apostrophecms-pro/palette': {}

--- a/backend/package.json
+++ b/backend/package.json
@@ -55,7 +55,6 @@
     "@apostrophecms-pro/import-export-translation": "^1.0.3",
     "@apostrophecms-pro/palette": "github:apostrophecms/palette",
     "@apostrophecms-pro/seo-assistant": "^1.2.1",
-    "@apostrophecms-pro/signup": "^2.0.2",
     "@apostrophecms/favicon": "github:apostrophecms/favicon",
     "@apostrophecms/mongodb-snapshot": "^1.1.0",
     "@apostrophecms/open-graph": "github:apostrophecms/open-graph",


### PR DESCRIPTION
This module needs an `@apostrophecms/signup:signup` template in the Astro project in order to work. See `signup.html`. 

Because a page template is required we can't fix it just by pushing nodes. We should probably just provide documented examples.